### PR TITLE
Fixed the Footer.vue container so that it shows up correctly

### DIFF
--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -33,7 +33,7 @@ export default {
 
 <style scoped>
 .container {
-  opacity: 90%;
+  opacity: 0.9;
   height: 34px;
   padding: 6px;
   width: 100%;


### PR DESCRIPTION
`opacity: 90%` isn't  standards compliant so now it is `opacity: 0.9`